### PR TITLE
Enhance mobile layout for project overview

### DIFF
--- a/index.html
+++ b/index.html
@@ -423,18 +423,19 @@
     .overview-container {
       display: grid;
       grid-template-columns: 1fr;
-      gap: 35px;
+      gap: 40px;
       margin-top: 30px;
     }
     @media (min-width: 768px) {
       .overview-container {
         grid-template-columns: repeat(3, 1fr);
+        gap: 35px;
       }
     }
     .overview-card {
-      background: linear-gradient(145deg, #f7fafc, #e6f0ff);
+      background: var(--light);
       border-radius: var(--border-radius-md);
-      padding: 25px;
+      padding: 30px;
       box-shadow: var(--shadow-md);
       transition: var(--transition-base);
       position: relative;
@@ -451,7 +452,7 @@
       left: 0;
       width: 100%;
       height: 5px;
-      background: linear-gradient(90deg, var(--main-blue), var(--main-orange));
+      background: var(--main-blue);
     }
     .overview-card h3 {
       color: var(--main-blue);
@@ -470,11 +471,23 @@
       line-height: 1.7;
     }
     .overview-card ul {
-      padding-left: 20px;
+      list-style: none;
+      padding-left: 0;
       margin-bottom: 15px;
     }
     .overview-card ul li {
       margin-bottom: 8px;
+      padding-left: 1.2em;
+      position: relative;
+    }
+    .overview-card ul li::before {
+      content: "\f0da";
+      font-family: "Font Awesome 6 Free";
+      font-weight: 900;
+      position: absolute;
+      left: 0;
+      top: 0.2em;
+      color: var(--main-orange);
     }
     .school-gallery {
       display: flex;
@@ -1196,13 +1209,19 @@
     }
 	 /* ======= 独立折叠/展开 样式 ======= */
     .overview-card .collapse-content {
-      max-height: 100px;         /* 初始显示高度 */
+      max-height: 60px;         /* 初始显示高度更紧凑 */
       overflow: hidden;
-      transition: max-height 0.4s ease;
+      transition: max-height 0.4s ease-in-out, opacity 0.4s ease-in-out;
+      opacity: 0;
+    }
+    @media (min-width: 768px) {
+      .overview-card .collapse-content {
+        max-height: 80px;
+      }
     }
     .overview-card .collapse-content.expanded {
-	 max-height: 600px;         /* 展开后高度足够显示全文 */
-      max-height: none;         /* 展开后无限制高度以完整显示内容 */
+      max-height: none;  /* 展开后无限制高度以完整显示内容 */
+      opacity: 1;
     }
     .toggle-btn {
       background: var(--main-orange);
@@ -1218,6 +1237,12 @@
       margin: 12px auto 0;
       display: inline-flex;
       align-items: center;
+    }
+    @media (max-width: 767px) {
+      .toggle-btn {
+        padding: 12px 24px;
+        font-size: 1rem;
+      }
     }
     .toggle-btn i {
       margin-right: 6px;


### PR DESCRIPTION
## Summary
- adjust project overview container gap
- simplify card background and header accent
- use font-awesome icons for overview lists
- tweak collapse animation and default height
- enlarge toggle button tap area on small screens

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_688ba0ec026c832cb7ae1e779b5f93c7